### PR TITLE
Fix social preview metadata for homepage sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,16 +3,32 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Portal oficial da Godoy Solutions in TECH - Dashboard Profissional">
+  <meta name="description" content="Godoy Solutions in TECH desenvolve soluções em automação, inteligência artificial, dashboards, sistemas web e experiências digitais inovadoras.">
   <meta name="author" content="Caíque Eduardo">
   <meta name="keywords" content="tecnologia, godoy solutions, tech, inovação, software, portal, dashboard">
-  <meta property="og:title" content="Godoy Solutions in TECH">
-  <meta property="og:description" content="Dashboard Profissional - Godoy Solutions in TECH">
+  <meta name="theme-color" content="#080d24">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="logonew.png">
+  <meta property="og:title" content="Godoy Solutions in TECH | Automação, IA e Sistemas Web">
+  <meta property="og:description" content="Godoy Solutions in TECH desenvolve soluções em automação, inteligência artificial, dashboards, sistemas web e experiências digitais inovadoras.">
   <meta property="og:url" content="https://godoysolutionstech.netlify.app/">
+  <meta property="og:site_name" content="Godoy Solutions in TECH">
+  <meta property="og:locale" content="pt_BR">
+  <meta property="og:image" content="https://godoysolutionstech.netlify.app/logo.png">
+  <meta property="og:image:secure_url" content="https://godoysolutionstech.netlify.app/logo.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="2000">
+  <meta property="og:image:height" content="1418">
+  <meta property="og:image:alt" content="Godoy Solutions in TECH - Automação, IA e Sistemas Web">
 
-  <title>Godoy Solutions in TECH</title>
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Godoy Solutions in TECH | Automação, IA e Sistemas Web">
+  <meta name="twitter:description" content="Godoy Solutions in TECH desenvolve soluções em automação, inteligência artificial, dashboards, sistemas web e experiências digitais inovadoras.">
+  <meta name="twitter:image" content="https://godoysolutionstech.netlify.app/logo.png">
+
+  <link rel="canonical" href="https://godoysolutionstech.netlify.app/">
+
+
+  <title>Godoy Solutions in TECH | Automação, IA e Sistemas Web</title>
 
   <!-- Ícones FontAwesome -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">


### PR DESCRIPTION
### Motivation
- Improve link preview rendering on WhatsApp, Facebook/Meta, Discord, Telegram, X/Twitter and LinkedIn by providing a complete Open Graph and Twitter Card set with absolute asset URLs.
- Replace the relative `og:image` and vertical branding asset for social previews with a horizontal, public image to ensure readable, branded previews.

### Description
- Updated `index.html` head to set a professional `title` and an expanded `meta[name="description"]` aligned with brand messaging.
- Added `theme-color`, a `canonical` link, and a full Open Graph set (`og:type`, `og:title`, `og:description`, `og:url`, `og:site_name`, `og:locale`, `og:image`, `og:image:secure_url`, `og:image:type`, `og:image:width`, `og:image:height`, `og:image:alt`) using absolute Netlify URLs.
- Added Twitter Card metadata (`twitter:card=summary_large_image`, `twitter:title`, `twitter:description`, `twitter:image`) and pointed social image metadata to `https://godoysolutionstech.netlify.app/logo.png` while keeping `logonew.png` as the favicon.
- Ensured the head has a single `title` and single `description` and removed relative/broken paths that can break crawlers.

### Testing
- Ran a Python HTML check script that validated there is exactly one `<title>`, one `meta name="description"`, and presence of required `og:` and `twitter:` tags, and the check passed.
- Ran an image-size detection script that confirmed `logo.png` is horizontal (`2000x1418`) and `logonew.png` is vertical (`1024x1536`), and the check passed.
- Reviewed the head diff to confirm metadata changes are confined to `index.html` and no layout or UX files were modified, and the review passed.
- Note: social previews may remain cached on platforms and typically require a deploy plus re-scrape via platform debuggers (Facebook Sharing Debugger, LinkedIn Post Inspector, Twitter Card Validator) for fresh previews.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b20837cc0c832f86cc7cea3b85c486)